### PR TITLE
topic-44 Add support for 'tags' data point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Added support for `tags` data point on goal records.
+  - `gl add "Do the needful" --tags foo,bar,baz`
+- Added support for filtering goals by tag.
+  - `gl list --tags foo`
 
 ### Changed
 - Updated CLI to display success message.

--- a/dist/commands/add.js
+++ b/dist/commands/add.js
@@ -17,6 +17,7 @@ function add(INPUT, ARGS, config) {
             title: title,
             category: ARGS.category || '',
             description: ARGS.description || '',
+            tags: ARGS.tags ? ARGS.tags.split(',').map(function (str) { return str.trim(); }) : [],
             complete: false,
             active: true
         };

--- a/dist/commands/list.js
+++ b/dist/commands/list.js
@@ -3,15 +3,19 @@ exports.__esModule = true;
 var chalk = require('chalk');
 function list(INPUT, ARGS, config) {
     return new Promise(function (resolve, reject) {
+        var CATEGORY = ARGS.category ? ARGS.category.toLowerCase() : null;
+        var TAGS = ARGS.tags ? ARGS.tags.split(',').map(function (str) { return str.trim().toLowerCase(); }) : [];
         var log = ARGS.archive ? config.utils.getLog('archive') : config.utils.getLog('active');
         var goals = log.goals;
         var whitelistProps = ['id', 'title'];
         var supplementaryProps = !ARGS.all && ARGS.show ? ARGS.show.split(',').filter(function (prop) { return whitelistProps.indexOf(prop) === -1; }) : [];
         var allGoals = Object.keys(goals).map(function (key) { return goals[key]; });
-        var filteredGoals = ARGS.category
+        var filteredGoals = (ARGS.category || TAGS.length)
             ? allGoals.filter(function (_a) {
-                var category = _a.category;
-                return !!category && category.toLowerCase().includes(ARGS.category.toLowerCase());
+                var category = _a.category, tags = _a.tags;
+                var sanitizedTags = tags && tags.length ? tags.map(function (tag) { return tag.toLowerCase(); }) : [];
+                return ((!!category && category.toLowerCase().includes(CATEGORY))
+                    || (!!sanitizedTags.length && sanitizedTags.some(function (tag) { return TAGS.includes(tag); })));
             })
             : allGoals;
         filteredGoals.forEach(function (goal) {

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -38,6 +38,7 @@ export default function add( INPUT: GoalistInput, ARGS: GoalistArgs, config: Goa
 			title: title,
 			category: ARGS.category || '',
 			description: ARGS.description || '',
+			tags: ARGS.tags ? ARGS.tags.split( ',' ).map((str) => str.trim()) : [],
 			complete: false,
 			active: true,
 		};

--- a/src/interfaces/goal.ts
+++ b/src/interfaces/goal.ts
@@ -2,11 +2,11 @@
 // PUBLIC API
 // --------------------------------------------------
 export interface Goal {
-	id: number,
-	title: string,
-	category?: string,
-	description?: string,
-	tags: string[],
-	complete: boolean,
-	active: boolean,
+	id: number;
+	title: string;
+	category?: string;
+	description?: string;
+	tags: string[];
+	complete: boolean;
+	active: boolean;
 };

--- a/src/interfaces/goal.ts
+++ b/src/interfaces/goal.ts
@@ -6,6 +6,7 @@ export interface Goal {
 	title: string,
 	category?: string,
 	description?: string,
+	tags: string[],
 	complete: boolean,
 	active: boolean,
 };

--- a/src/interfaces/goal.ts
+++ b/src/interfaces/goal.ts
@@ -4,8 +4,8 @@
 export interface Goal {
 	id: number;
 	title: string;
-	category?: string;
-	description?: string;
+	category: string;
+	description: string;
 	tags: string[];
 	complete: boolean;
 	active: boolean;

--- a/src/interfaces/goalist.ts
+++ b/src/interfaces/goalist.ts
@@ -39,6 +39,7 @@ export interface GoalistArgs {
 	archive?: boolean;
 	category?: string;
 	description?: string;
+	tags?: string;
 	false?: boolean;
 	force?: boolean;
 	show?: string;

--- a/test/commands/add.test.js
+++ b/test/commands/add.test.js
@@ -55,9 +55,15 @@ test( 'should write the new goal data to disk', ( t ) => {
   const generateId = config.utils.generateId = sinon.spy( () => id );
   const writeLog = config.utils.writeLog = sinon.spy();
 
-  add( [ title ], {}, config );
-
-  t.is( writeLog.calledWith( 'active', JSON.stringify( { goals: { [id]: goal } } ) ), true );
+	return add( [ title ], { tags: 'foo, bar, baz' }, config ).then((goal) => {
+		t.is(
+			writeLog.calledWith(
+				'active',
+				JSON.stringify( { goals: { [id]: Object.assign({}, goal, { tags: [ 'foo', 'bar', 'baz' ] } ) } } )
+			),
+			true
+		);
+	});
 } );
 
 test( 'it should reject if no "title" is provided', ( t ) => {

--- a/test/commands/list.test.js
+++ b/test/commands/list.test.js
@@ -123,3 +123,35 @@ test( 'it should allow goals to be filtered by category', ( t ) => {
   t.is(args.some( ( arg ) => arg.includes( title1 ) ), true);
   t.is(args.every( ( arg ) => !arg.includes( title2 ) ), true);
 } );
+
+test( 'it should allow goals to be filtered by tag', ( t ) => {
+  const title1 = 'Goal 1';
+  const title2 = 'Goal 2';
+  const category1 = 'Foo';
+  const category2 = 'Bar';
+  const goal1 = { title: title1, tags: [ 'foo', 'bar' ] };
+  const goal2 = { title: title2, tags: [ 'baz', 'quux' ] };
+  const getLog = config.utils.getLog = sinon.spy( () => ( { goals: { '1': goal1, '2': goal2 } } ) );
+  const log = config.debugger.log = sinon.spy();
+
+  list( [], { tags: 'foo,bar' }, config );
+
+  // Flatten `log()` arugments into a 1-dimensional array.
+  const args = log.args.reduce( ( acc, args ) => [...acc, ...args], [] );
+  t.is(args.some( ( arg ) => arg.includes( title1 ) ), true);
+  t.is(args.every( ( arg ) => !arg.includes( title2 ) ), true);
+} );
+
+test( 'it should allow goals to be filtered by category or tag', ( t ) => {
+  const goal1 = { title, tags: [ 'foo', 'bar' ] };
+  const goal2 = { title: title2, category: 'baz' };
+  const getLog = config.utils.getLog = sinon.spy( () => ( { goals: { '1': goal1, '2': goal2 } } ) );
+  const log = config.debugger.log = sinon.spy();
+
+  list( [], { tags: 'foo,bar', category: 'baz' }, config );
+
+  // Flatten `log()` arugments into a 1-dimensional array.
+  const args = log.args.reduce( ( acc, args ) => [...acc, ...args], [] );
+  t.is(args.some( ( arg ) => arg.includes( title ) ), true);
+  t.is(args.some( ( arg ) => arg.includes( title2 ) ), true);
+} );

--- a/test/commands/list.test.js
+++ b/test/commands/list.test.js
@@ -14,6 +14,9 @@ const { default: list } = require('../../dist/commands/list');
 let config;
 let id;
 let title;
+let title2;
+let category;
+let category2;
 let description;
 let complete;
 let active;
@@ -24,6 +27,9 @@ let active;
 test.beforeEach(() => {
   id = 'TEST_ID';
   title = 'TEST_TITLE';
+  title2 = 'TEST_TITLE_2';
+  category = 'Foo';
+  category2 = 'Bar';
   description = 'TEST_DESCRIPTION';
   complete = 'TEST_COMPLETE';
   active = 'TEST_ACTIVE';
@@ -107,29 +113,21 @@ test( 'should display all of the data for each goal when the "all" argument is p
 } );
 
 test( 'it should allow goals to be filtered by category', ( t ) => {
-  const title1 = 'Goal 1';
-  const title2 = 'Goal 2';
-  const category1 = 'Foo';
-  const category2 = 'Bar';
-  const goal1 = { title: title1, category: category1 };
+  const goal1 = { title, category };
   const goal2 = { title: title2, category: category2 };
   const getLog = config.utils.getLog = sinon.spy( () => ( { goals: { '1': goal1, '2': goal2 } } ) );
   const log = config.debugger.log = sinon.spy();
 
-  list( [], { category: category1 }, config );
+  list( [], { category }, config );
 
   // Flatten `log()` arugments into a 1-dimensional array.
   const args = log.args.reduce( ( acc, args ) => [...acc, ...args], [] );
-  t.is(args.some( ( arg ) => arg.includes( title1 ) ), true);
+  t.is(args.some( ( arg ) => arg.includes( title ) ), true);
   t.is(args.every( ( arg ) => !arg.includes( title2 ) ), true);
 } );
 
 test( 'it should allow goals to be filtered by tag', ( t ) => {
-  const title1 = 'Goal 1';
-  const title2 = 'Goal 2';
-  const category1 = 'Foo';
-  const category2 = 'Bar';
-  const goal1 = { title: title1, tags: [ 'foo', 'bar' ] };
+  const goal1 = { title, tags: [ 'foo', 'bar' ] };
   const goal2 = { title: title2, tags: [ 'baz', 'quux' ] };
   const getLog = config.utils.getLog = sinon.spy( () => ( { goals: { '1': goal1, '2': goal2 } } ) );
   const log = config.debugger.log = sinon.spy();
@@ -138,7 +136,7 @@ test( 'it should allow goals to be filtered by tag', ( t ) => {
 
   // Flatten `log()` arugments into a 1-dimensional array.
   const args = log.args.reduce( ( acc, args ) => [...acc, ...args], [] );
-  t.is(args.some( ( arg ) => arg.includes( title1 ) ), true);
+  t.is(args.some( ( arg ) => arg.includes( title ) ), true);
   t.is(args.every( ( arg ) => !arg.includes( title2 ) ), true);
 } );
 


### PR DESCRIPTION
This pull request introduces the following functionality:
- Tag data can now be added to goals.
  - `gl add "Do the needful" --tags friday,important`
- Goals can now be filtered by tag.
  - `gl list --tags important`
